### PR TITLE
Fixed issue on missing watt values in import file

### DIFF
--- a/ZonPHP/importer/sunny_explorer.php
+++ b/ZonPHP/importer/sunny_explorer.php
@@ -45,8 +45,11 @@ function mapLinesToDBValues(array $lines, string $name, $lastImportDate, $import
                 $currentTimeStamp = date("Y-m-d H:i:s", $convertedTimeStamp);
                 $currentkWhCounter = str_replace(',', '.', $lineValues[1]);
                 $cummulatedkWh = number_format($currentkWhCounter - $minkWhCounter, 3);
-                $currentWatt = str_replace(',', '.', $lineValues[2]) * 1000;
-
+                $currentWatt = 0;
+                $currentWattStr = trim(str_replace(',', '.', $lineValues[2]));
+                if (strlen($currentWattStr) > 0 && is_numeric($currentWattStr)) {
+                    $currentWatt = $currentWattStr * 1000;
+                }
                 // insert only new data and value > 0
                 if ($currentWatt > 0 && ($currentTimeStamp != "") && (strtotime($currentTimeStamp) > strtotime($lastImportDate))) {
                     $dbValues[] = array('name' => $name, 'timestamp' => $currentTimeStamp, 'watt' => $currentWatt, 'cummulatedkWh' => number_format($cummulatedkWh, 3));

--- a/ZonPHP/inc/version_info.php
+++ b/ZonPHP/inc/version_info.php
@@ -2,7 +2,7 @@
 /********************************************************************
  * Version
  *********************************************************************/
-$version = "v3.3.6";
+$version = "v3.3.7";
 
 // Change SessionId if needed e.g. if you run multi instances
 $zonPHPSessionID = "SOLAR_" . str_replace('.', '_', $version);


### PR DESCRIPTION
Fixed Issue: https://github.com/seehase/ZonPHP/issues/99

Importer is more resilient on missing values (kW), and set default to 0

```
;Counter;Analog
dd.MM.yyyy HH:mm:ss;kWh;kW
02.02.2023 08:50:00;22981.102
02.02.2023 08:55:00;22981.105;0.036
```