### PR TITLE
Changed number_format -> round

### DIFF
--- a/ZonPHP/importer/sunny_explorer.php
+++ b/ZonPHP/importer/sunny_explorer.php
@@ -44,7 +44,7 @@ function mapLinesToDBValues(array $lines, string $name, $lastImportDate, $import
                 $convertedTimeStamp = convertToUnixTimestamp($convertedDate);
                 $currentTimeStamp = date("Y-m-d H:i:s", $convertedTimeStamp);
                 $currentkWhCounter = str_replace(',', '.', $lineValues[1]);
-                $cummulatedkWh = number_format($currentkWhCounter - $minkWhCounter, 3);
+                $cummulatedkWh = round($currentkWhCounter - $minkWhCounter, 3);
                 $currentWatt = 0;
                 $currentWattStr = trim(str_replace(',', '.', $lineValues[2]));
                 if (strlen($currentWattStr) > 0 && is_numeric($currentWattStr)) {
@@ -52,7 +52,7 @@ function mapLinesToDBValues(array $lines, string $name, $lastImportDate, $import
                 }
                 // insert only new data and value > 0
                 if ($currentWatt > 0 && ($currentTimeStamp != "") && (strtotime($currentTimeStamp) > strtotime($lastImportDate))) {
-                    $dbValues[] = array('name' => $name, 'timestamp' => $currentTimeStamp, 'watt' => $currentWatt, 'cummulatedkWh' => number_format($cummulatedkWh, 3));
+                    $dbValues[] = array('name' => $name, 'timestamp' => $currentTimeStamp, 'watt' => $currentWatt, 'cummulatedkWh' => round($cummulatedkWh, 3));
                 }
             }
         }

--- a/ZonPHP/inc/version_info.php
+++ b/ZonPHP/inc/version_info.php
@@ -2,7 +2,7 @@
 /********************************************************************
  * Version
  *********************************************************************/
-$version = "v3.3.8";
+$version = "v3.3.9";
 
 // Change SessionId if needed e.g. if you run multi instances
 $zonPHPSessionID = "SOLAR_" . str_replace('.', '_', $version);


### PR DESCRIPTION
No sure why this as ever worked before, but no need to format values, only rounding is valid
Formating adds thousend separator which cannot be handled, and is not needed
https://github.com/seehase/ZonPHP/issues/99