### PR TITLE
fix: DayChart use string instead of int, because it can fail on 32-bit systems

### DIFF
--- a/ZonPHP/charts/day_chart.php
+++ b/ZonPHP/charts/day_chart.php
@@ -137,10 +137,13 @@ foreach (PLANT_NAMES as $key => $inverter_name) {
             }
             $cumDataString .= "{x: $timeInMillis, y: $cumSum},";
             $dataSeriesString .= '{x:' . $timeInMillis . ', y: ' . $currentInverterVal . '},';
-            if (!isset($totalsumCumArray[$timeInMillis])) {
-                $totalsumCumArray[$timeInMillis] = 0;
+            // Cast the large number to a string to support 32-bit and 64-bit systems
+            $timeKey = (string)$timeInMillis;
+
+            if (!isset($totalsumCumArray[$timeKey])) {
+                $totalsumCumArray[$timeKey] = 0;
             }
-            $totalsumCumArray[$timeInMillis] += $cumSum;
+            $totalsumCumArray[$timeKey] += $cumSum;
         }
 
         $dataZonPHP[$inverter_name]['totalValue'] = $cumSum;

--- a/ZonPHP/inc/version_info.php
+++ b/ZonPHP/inc/version_info.php
@@ -3,7 +3,7 @@
  * Version
  *********************************************************************/
 
-$version = "v4.4.5";
+$version = "v4.4.6";
 
 // Change SessionId if needed e.g. if you run multi instances
 $zonPHPSessionID = "SOLAR_" . str_replace('.', '_', $version);


### PR DESCRIPTION

This fix issue https://github.com/seehase/ZonPHP/issues/126
I used unix timestamp millis as index, which fails on 32bit systems because 1774071900000 is bigger then int32
Change to string works on all systems