### PR TITLE
Fix: Removed duplicate function parseImportDateTimeFormat()

### DIFF
--- a/ZonPHP/importer/sunny_explorer_multi.php
+++ b/ZonPHP/importer/sunny_explorer_multi.php
@@ -73,27 +73,3 @@ function mapLinesToDBValues(array $lines, string $name, $lastImportDate, $import
     return $dbValues;
 }
 
-/**
- * Try to parse dateformat from CSV wich is normaly written in line 9
- * dd.MM.yyyy HH:mm:ss;kWh;kW
- * -->  "d.m.Y H:i:s"
- */
-function parseImportDateTimeFormat(string $line, string $default): string
-{
-    $parts = explode(";", $line);
-    if (count($parts) > 0) {
-        $format = $parts[0];
-        $format = str_replace("dd", "d", $format);
-        $format = str_replace("MM", "m", $format);
-        $format = str_replace("yyyy", "Y", $format);
-        $format = str_replace("HH", "H", $format);
-        $format = str_replace("mm", "i", $format);
-        $format = str_replace("ss", "s", $format);
-        addDebugInfo("parseImportDateTimeFormat: parsed import format from CSV: $line -> $format");
-        return $format;
-    } else {
-        addDebugInfo("parseImportDateTimeFormat: cannot parse import format from CSV: $line using default: $default override in [plant][importDateFormat] if needed");
-        return $default;
-    }
-
-}

--- a/ZonPHP/importer/sunny_explorer_multi_cumulated.php
+++ b/ZonPHP/importer/sunny_explorer_multi_cumulated.php
@@ -80,28 +80,3 @@ function mapLinesToDBValues(array $lines, string $name, $lastImportDate, $import
     addDebugInfo("sunny_explorer_multi_cumulated: mapLinesToDBValues: ImportedLines: " . count($lines) . " - DataRows: " . count($dbValues));
     return $dbValues;
 }
-
-/**
- * Try to parse dateformat from CSV wich is normaly written in line 9
- * dd.MM.yyyy HH:mm:ss;kWh;kW
- * -->  "d.m.Y H:i:s"
- */
-function parseImportDateTimeFormat(string $line, string $default): string
-{
-    $parts = explode(";", $line);
-    if (count($parts) > 0) {
-        $format = $parts[0];
-        $format = str_replace("dd", "d", $format);
-        $format = str_replace("MM", "m", $format);
-        $format = str_replace("yyyy", "Y", $format);
-        $format = str_replace("HH", "H", $format);
-        $format = str_replace("mm", "i", $format);
-        $format = str_replace("ss", "s", $format);
-        addDebugInfo("parseImportDateTimeFormat: parsed import format from CSV: $line -> $format");
-        return $format;
-    } else {
-        addDebugInfo("parseImportDateTimeFormat: cannot parse import format from CSV: $line using default: $default override in [plant][importDateFormat] if needed");
-        return $default;
-    }
-
-}

--- a/ZonPHP/inc/version_info.php
+++ b/ZonPHP/inc/version_info.php
@@ -3,7 +3,7 @@
  * Version
  *********************************************************************/
 
-$version = "v4.4.6";
+$version = "v4.4.7";
 
 // Change SessionId if needed e.g. if you run multi instances
 $zonPHPSessionID = "SOLAR_" . str_replace('.', '_', $version);


### PR DESCRIPTION
Importer sunny_explorer_multi.php throws fatal Error because it tries to redefine the function that is already defined in common.php (moved there from sunny_explorer.php?).